### PR TITLE
ADDED: Wal changes

### DIFF
--- a/database/src/database/table/table.rs
+++ b/database/src/database/table/table.rs
@@ -4,7 +4,6 @@ use thiserror::Error;
 
 use crate::{
     consts::consts::{EntityId, TransactionId, VersionId},
-    database::snapshot::Metadata,
     model::{
         action::{Action, ActionResult},
         person::Person,


### PR DESCRIPTION
Updates:
- So that the transaction log is more descriptive of what is it doing (acting as a WAL), the name has been updated
- Removed in-memory list of transactions; this is not needed because we store them on disk
- The changes only get written to the WAL once they are considered 'committed.'
- Adds fsync (sync_all) to ensure commit durability