### PR TITLE
Feat/multiple threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "env_logger",
+ "flume",
  "log",
  "num-format",
  "oneshot",
@@ -896,6 +897,18 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
 ]
 
 [[package]]
@@ -1060,8 +1073,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1087,6 +1102,7 @@ dependencies = [
  "ctrlc",
  "database",
  "env_logger",
+ "flume",
  "juniper",
  "log",
  "uuid 1.7.0",
@@ -1460,6 +1476,15 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -2039,6 +2064,15 @@ checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/clients/data/transaction_log.json
+++ b/clients/data/transaction_log.json
@@ -1,36 +1,8 @@
-{"id":2,"statements":[{"List":null}],"status":"Committed"}
-{"id":3,"statements":[{"List":null}],"status":"Committed"}
-{"id":4,"statements":[{"Add":{"id":"2e20fd2f-f23d-4523-a60c-7cb1a0a922b6","full_name":"Frank Walker","email":null}}],"status":"Committed"}
-{"id":5,"statements":[{"Add":{"id":"b3e63938-5280-4a1b-9efe-bbb2b422e69e","full_name":"Frank Walker","email":null}}],"status":"Committed"}
-{"id":6,"statements":[{"Add":{"id":"2a6704a8-b224-4892-bac2-08426ec74fea","full_name":"Frank Walker","email":null}}],"status":"Committed"}
-{"id":7,"statements":[{"Add":{"id":"b28a5ebe-5c5f-45cc-bc0a-b3d5458e0274","full_name":"Frank Walker","email":null}}],"status":"Committed"}
-{"id":8,"statements":[{"Add":{"id":"aa9fd7d6-5f49-41ee-ae64-3913fb246c43","full_name":"Frank Walker","email":null}}],"status":"Committed"}
-{"id":9,"statements":[{"Add":{"id":"714a72a8-e3d2-40e0-a10a-28079b9eef05","full_name":"Frank Walker","email":null}}],"status":"Committed"}
-{"id":10,"statements":[{"Add":{"id":"e0ea138a-0375-42da-a2cc-7a9302052f67","full_name":"Frank Walker","email":null}}],"status":"Committed"}
-{"id":11,"statements":[{"List":null}],"status":"Committed"}
-{"id":12,"statements":[{"List":null}],"status":"Committed"}
-{"id":13,"statements":[{"List":null}],"status":"Committed"}
-{"id":14,"statements":[{"List":null}],"status":"Committed"}
-{"id":15,"statements":[{"List":null}],"status":"Committed"}
-{"id":16,"statements":[{"List":null}],"status":"Committed"}
-{"id":17,"statements":[{"List":null}],"status":"Committed"}
-{"id":18,"statements":[{"List":null}],"status":"Committed"}
-{"id":19,"statements":[{"List":null}],"status":"Committed"}
-{"id":20,"statements":[{"List":null}],"status":"Committed"}
-{"id":21,"statements":[{"List":null}],"status":"Committed"}
-{"id":22,"statements":[{"List":null}],"status":"Committed"}
-{"id":23,"statements":[{"List":null}],"status":"Committed"}
-{"id":24,"statements":[{"List":null}],"status":"Committed"}
-{"id":25,"statements":[{"List":null}],"status":"Committed"}
-{"id":26,"statements":[{"List":null}],"status":"Committed"}
-{"id":27,"statements":[{"List":null}],"status":"Committed"}
-{"id":28,"statements":[{"List":null}],"status":"Committed"}
-{"id":29,"statements":[{"List":null}],"status":"Committed"}
-{"id":30,"statements":[{"List":null}],"status":"Committed"}
-{"id":31,"statements":[{"List":null}],"status":"Committed"}
-{"id":32,"statements":[{"List":null}],"status":"Committed"}
-{"id":33,"statements":[{"List":null}],"status":"Committed"}
-{"id":34,"statements":[{"List":null}],"status":"Committed"}
-{"id":35,"statements":[{"List":null}],"status":"Committed"}
-{"id":36,"statements":[{"List":null}],"status":"Committed"}
-{"id":37,"statements":[{"List":null}],"status":"Committed"}
+{"id":2,"statements":[{"Add":{"id":"3c0d9fd6-99ac-4a7e-8fba-d6bef89c99ae","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":3,"statements":[{"Add":{"id":"1660944d-829c-445b-879f-f444f1e8ca3d","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":4,"statements":[{"Add":{"id":"55bf6b02-ff2b-418a-a1e4-f02e9f8427ba","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":5,"statements":[{"Add":{"id":"a027a717-3993-4b93-8173-09959a7141f6","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":6,"statements":[{"Add":{"id":"3898162e-b513-4336-946e-da8aca9e2e43","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":7,"statements":[{"Add":{"id":"3cfba53c-295d-42ff-91fa-68a04112cd93","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":8,"statements":[{"Add":{"id":"6ed01029-cc6f-4476-b804-7676304acaff","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":9,"statements":[{"Add":{"id":"f2215799-c700-401b-9c75-4898109cfc7d","full_name":"Frank Walker","email":null}}],"status":"Committed"}

--- a/clients/data/transaction_log.json
+++ b/clients/data/transaction_log.json
@@ -1,0 +1,10 @@
+{"id":2,"statements":[{"List":null}],"status":"Committed"}
+{"id":3,"statements":[{"List":null}],"status":"Committed"}
+{"id":4,"statements":[{"Add":{"id":"2e20fd2f-f23d-4523-a60c-7cb1a0a922b6","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":5,"statements":[{"Add":{"id":"b3e63938-5280-4a1b-9efe-bbb2b422e69e","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":6,"statements":[{"Add":{"id":"2a6704a8-b224-4892-bac2-08426ec74fea","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":7,"statements":[{"Add":{"id":"b28a5ebe-5c5f-45cc-bc0a-b3d5458e0274","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":8,"statements":[{"Add":{"id":"aa9fd7d6-5f49-41ee-ae64-3913fb246c43","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":9,"statements":[{"Add":{"id":"714a72a8-e3d2-40e0-a10a-28079b9eef05","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":10,"statements":[{"Add":{"id":"e0ea138a-0375-42da-a2cc-7a9302052f67","full_name":"Frank Walker","email":null}}],"status":"Committed"}
+{"id":11,"statements":[{"List":null}],"status":"Committed"}

--- a/clients/data/transaction_log.json
+++ b/clients/data/transaction_log.json
@@ -8,3 +8,29 @@
 {"id":9,"statements":[{"Add":{"id":"714a72a8-e3d2-40e0-a10a-28079b9eef05","full_name":"Frank Walker","email":null}}],"status":"Committed"}
 {"id":10,"statements":[{"Add":{"id":"e0ea138a-0375-42da-a2cc-7a9302052f67","full_name":"Frank Walker","email":null}}],"status":"Committed"}
 {"id":11,"statements":[{"List":null}],"status":"Committed"}
+{"id":12,"statements":[{"List":null}],"status":"Committed"}
+{"id":13,"statements":[{"List":null}],"status":"Committed"}
+{"id":14,"statements":[{"List":null}],"status":"Committed"}
+{"id":15,"statements":[{"List":null}],"status":"Committed"}
+{"id":16,"statements":[{"List":null}],"status":"Committed"}
+{"id":17,"statements":[{"List":null}],"status":"Committed"}
+{"id":18,"statements":[{"List":null}],"status":"Committed"}
+{"id":19,"statements":[{"List":null}],"status":"Committed"}
+{"id":20,"statements":[{"List":null}],"status":"Committed"}
+{"id":21,"statements":[{"List":null}],"status":"Committed"}
+{"id":22,"statements":[{"List":null}],"status":"Committed"}
+{"id":23,"statements":[{"List":null}],"status":"Committed"}
+{"id":24,"statements":[{"List":null}],"status":"Committed"}
+{"id":25,"statements":[{"List":null}],"status":"Committed"}
+{"id":26,"statements":[{"List":null}],"status":"Committed"}
+{"id":27,"statements":[{"List":null}],"status":"Committed"}
+{"id":28,"statements":[{"List":null}],"status":"Committed"}
+{"id":29,"statements":[{"List":null}],"status":"Committed"}
+{"id":30,"statements":[{"List":null}],"status":"Committed"}
+{"id":31,"statements":[{"List":null}],"status":"Committed"}
+{"id":32,"statements":[{"List":null}],"status":"Committed"}
+{"id":33,"statements":[{"List":null}],"status":"Committed"}
+{"id":34,"statements":[{"List":null}],"status":"Committed"}
+{"id":35,"statements":[{"List":null}],"status":"Committed"}
+{"id":36,"statements":[{"List":null}],"status":"Committed"}
+{"id":37,"statements":[{"List":null}],"status":"Committed"}

--- a/clients/graphql/Cargo.toml
+++ b/clients/graphql/Cargo.toml
@@ -20,3 +20,4 @@ log = "0.4"
 uuid = { version = "1.5.0", features = ["v4"] }
 clap = { version = "4.0", features = ["derive"] }
 ctrlc = "3.4.2"
+flume = "0.11.0"

--- a/clients/graphql/src/main.rs
+++ b/clients/graphql/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> io::Result<()> {
 
     let database_options = DatabaseOptions::default().set_data_directory(args.data);
 
-    let database_sender = Database::new(database_options).run();
+    let database_sender = Database::new(database_options).run(5);
 
     // Set up Ctrl-C handler
     let set_handler_database_sender_clone = database_sender.clone();

--- a/clients/tcp-server/src/main.rs
+++ b/clients/tcp-server/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
     let database_options = DatabaseOptions::default().set_data_directory(args.data);
 
     // Setup database
-    let database_sender = Database::new(database_options).run();
+    let database_sender = Database::new(database_options).run(5);
 
     let listener = TcpListener::bind(format!("{}:{}", args.address, args.port)).unwrap();
 

--- a/clients/tcp-server/src/main.rs
+++ b/clients/tcp-server/src/main.rs
@@ -1,12 +1,10 @@
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::str::from_utf8;
-use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 
 use clap::Parser;
 use database::consts::consts::EntityId;
-use database::database::commands::DatabaseCommandRequest;
 use database::database::database::{Database, DatabaseOptions};
 use database::database::request_manager::RequestManager;
 use database::database::table::row::{UpdatePersonData, UpdateStatement};
@@ -40,17 +38,8 @@ fn main() {
 
     let database_options = DatabaseOptions::default().set_data_directory(args.data);
 
-    let (database_sender, database_receiver): (
-        Sender<DatabaseCommandRequest>,
-        Receiver<DatabaseCommandRequest>,
-    ) = mpsc::channel();
-
-    // Setup database thread
-    thread::spawn(move || {
-        let mut database = Database::new(database_receiver, database_options);
-
-        database.run();
-    });
+    // Setup database
+    let database_sender = Database::new(database_options).run();
 
     let listener = TcpListener::bind(format!("{}:{}", args.address, args.port)).unwrap();
 

--- a/clients/tcp-server/src/main.rs
+++ b/clients/tcp-server/src/main.rs
@@ -6,7 +6,6 @@ use std::thread;
 use clap::Parser;
 use database::consts::consts::EntityId;
 use database::database::database::{Database, DatabaseOptions};
-use database::database::request_manager::RequestManager;
 use database::database::table::row::{UpdatePersonData, UpdateStatement};
 use database::model::person::Person;
 use database::model::statement::Statement; // TCP Stream defines implementation
@@ -39,14 +38,14 @@ fn main() {
     let database_options = DatabaseOptions::default().set_data_directory(args.data);
 
     // Setup database
-    let database_sender = Database::new(database_options).run(5);
+    let rm = Database::new(database_options).run(5);
 
     let listener = TcpListener::bind(format!("{}:{}", args.address, args.port)).unwrap();
 
     loop {
         match listener.accept() {
             Ok((mut stream, _)) => {
-                let request_manager = RequestManager::new(database_sender.clone());
+                let request_manager = rm.clone();
 
                 thread::spawn(move || {
                     println!("Connected stream");

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4"
 uuid = { version = "1.5.0", features = ["v4"] }
 num-format = "0.4.4"
 thiserror = "1.0.56"
+flume = "0.11.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/database/src/database/request_manager.rs
+++ b/database/src/database/request_manager.rs
@@ -18,6 +18,7 @@ use super::{
     table::{query::QueryPersonData, row::UpdatePersonData},
 };
 
+#[derive(Clone)]
 pub struct RequestManager {
     database_sender: flume::Sender<DatabaseCommandRequest>,
 }

--- a/database/src/database/request_manager.rs
+++ b/database/src/database/request_manager.rs
@@ -158,7 +158,7 @@ impl RequestManager {
         //  on the response_receiver once it's finished processing it's request
         self.database_sender.send(request).unwrap();
 
-        let response = response_receiver.recv_timeout(Duration::from_secs(5));
+        let response = response_receiver.recv_timeout(Duration::from_secs(10));
 
         match response {
             // Transaction commands

--- a/database/src/database/request_manager.rs
+++ b/database/src/database/request_manager.rs
@@ -1,5 +1,5 @@
 use core::panic;
-use std::{sync::mpsc::Sender, time::Duration};
+use std::time::Duration;
 use thiserror::Error;
 
 use crate::{
@@ -19,7 +19,7 @@ use super::{
 };
 
 pub struct RequestManager {
-    database_sender: Sender<DatabaseCommandRequest>,
+    database_sender: flume::Sender<DatabaseCommandRequest>,
 }
 
 /// Converts the database command hierarchy into a simple string, this is an easy interface to work with
@@ -40,7 +40,7 @@ pub enum RequestManagerError {
 
 /// Goal of the request manager is to provide a simple interface for interacting with the database
 impl RequestManager {
-    pub fn new(database_sender: Sender<DatabaseCommandRequest>) -> Self {
+    pub fn new(database_sender: flume::Sender<DatabaseCommandRequest>) -> Self {
         Self { database_sender }
     }
 

--- a/database/src/database/snapshot.rs
+++ b/database/src/database/snapshot.rs
@@ -142,7 +142,7 @@ impl SnapshotManager {
         return (snapeshot_count, metadata_data);
     }
 
-    pub fn create_snapshot(&self, table: &mut PersonTable, transaction_id: TransactionId) {
+    pub fn create_snapshot(&mut self, table: &mut PersonTable, transaction_id: TransactionId) {
         // -- Table
         let result = table
             .apply(Statement::ListLatestVersions, transaction_id.clone())

--- a/database/src/model/statement.rs
+++ b/database/src/model/statement.rs
@@ -24,6 +24,10 @@ pub enum Statement {
 }
 
 impl Statement {
+    pub fn is_query(&self) -> bool {
+        !self.is_mutation()
+    }
+
     pub fn is_mutation(&self) -> bool {
         match self {
             Statement::Add(_) | Statement::Remove(_) | Statement::Update(_, _) => true,


### PR DESCRIPTION
Changes:
- Added support for multiple database threads
   - Moved thread ownership into the database
   - Wraps the database in a RW lock for shared access
- Changed from a mpsc channel to a mpmc flume channel
- The query / read-only path skips the WAL 

Observations:
Multiple database threads ALWAYS slow things down (EVEN in the read case), theories:
1. The `database_test` waits for the response, before posting another request, causing a 'ping-pong'
2. Time to spin up threads might be non-trivial and add to the cost of this test
3. A multi-threaded database would make more sense when working on different tables / higher read throughput 
4. Would a single writer / multiple reader threads make work more performant, less switching? 

Future use cases:
1. Can we break the locking into table level? It would improve cross-table performance. 
   1. Lock table when attempting to perform a transaction -- then lock the WAL when performing a write