### PR TITLE
Feat/task request manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,20 @@ cargo run --package tcp-server --bin lineagedb-tcp-server
 **Testing / Benchmarking**
 
 ```
+# Quick functional unit tests
 cargo test --all
 
+# Running performance unit tests
+# Notes:
+# 1. Running these tests one after another will yield different results to
+#   running them individually. I suspect this could be because the OS' cleaning up allocated memory.
+# 2. These tests will yield different results based on whether the laptop is charging or not
+cargo test --package database "database::database::tests::bulk" -- --nocapture --ignored
+
 # Benchmarking https://bheisler.github.io/criterion.rs/book/user_guide/command_line_options.html#baselines
+# There appears to be an issue with 'benchmark' that spin up multiple
+#   threads in the database. It causes 100x performance lags. 800us to 80ms
+# Seems that the performance unit tests are a more reliable indicator
 cargo bench --all
 cargo bench -- --save-baseline no-fsync # Saves the baseline to compare to another branch
 ```

--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ RUST_BACKTRACE=1 cargo run
 cargo run --package tcp-server --bin lineagedb-tcp-server
 ```
 
+**Performance**
+
+Tested on an M1 Mac.
+
+```
+Read speed ~800k statements/s
+Write speed ~80k statements/s
+```
+
 **Testing / Benchmarking**
 
 ```
@@ -154,6 +163,7 @@ cargo test --package database "database::database::tests::bulk" -- --nocapture -
 cargo bench --all
 cargo bench -- --save-baseline no-fsync # Saves the baseline to compare to another branch
 ```
+
 
 ## Notes
 

--- a/database/benches/my_benchmark.rs
+++ b/database/benches/my_benchmark.rs
@@ -13,7 +13,7 @@ use database::{
 use uuid::Uuid;
 
 const WORKER_THREADS: u32 = 2;
-const DATABASE_THREADS: u32 = 2;
+const DATABASE_THREADS: u32 = 1;
 
 /// Actions are split across threads, so this is the total number of actions
 const ACTIONS: u32 = 100;

--- a/database/benches/my_benchmark.rs
+++ b/database/benches/my_benchmark.rs
@@ -13,6 +13,9 @@ use database::{
 use uuid::Uuid;
 
 const WORKER_THREADS: u32 = 2;
+
+/// There appears to be a weird issue where benchmarking with multiple threads kills performance
+/// by 100x 800us -> 80ms. Do not increase the thread count until this is resolved
 const DATABASE_THREADS: u32 = 1;
 
 /// Actions are split across threads, so this is the total number of actions

--- a/database/benches/my_benchmark.rs
+++ b/database/benches/my_benchmark.rs
@@ -29,7 +29,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 })
             };
 
-            database_test(WORKER_THREADS, DATABASE_THREADS, ACTIONS, action_generator);
+            database_test(
+                WORKER_THREADS,
+                DATABASE_THREADS,
+                ACTIONS,
+                action_generator,
+                None,
+            );
         })
     });
 
@@ -57,7 +63,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 );
             };
 
-            database_test(WORKER_THREADS, DATABASE_THREADS, ACTIONS, action_generator);
+            database_test(
+                WORKER_THREADS,
+                DATABASE_THREADS,
+                ACTIONS,
+                action_generator,
+                None,
+            );
         })
     });
 
@@ -79,7 +91,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 return Statement::Get(id);
             };
 
-            database_test(WORKER_THREADS, DATABASE_THREADS, ACTIONS, action_generator);
+            database_test(
+                WORKER_THREADS,
+                DATABASE_THREADS,
+                ACTIONS,
+                action_generator,
+                None,
+            );
         })
     });
 
@@ -101,7 +119,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 }
             };
 
-            database_test(WORKER_THREADS, DATABASE_THREADS, ACTIONS, action_generator);
+            database_test(
+                WORKER_THREADS,
+                DATABASE_THREADS,
+                ACTIONS,
+                action_generator,
+                None,
+            );
         })
     });
 
@@ -124,7 +148,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 }
             };
 
-            database_test(WORKER_THREADS, DATABASE_THREADS, ACTIONS, action_generator);
+            database_test(
+                WORKER_THREADS,
+                DATABASE_THREADS,
+                ACTIONS,
+                action_generator,
+                None,
+            );
         })
     });
 

--- a/database/benches/my_benchmark.rs
+++ b/database/benches/my_benchmark.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use database::{
     consts::consts::EntityId,
     database::{
-        database::test_utils::database_test,
+        database::test_utils::{database_test, database_test_task},
         table::{
             query::{QueryMatch, QueryPersonData},
             row::{UpdatePersonData, UpdateStatement},
@@ -13,7 +13,7 @@ use database::{
 use uuid::Uuid;
 
 const WORKER_THREADS: u32 = 2;
-const DATABASE_THREADS: u32 = 1;
+const DATABASE_THREADS: u32 = 2;
 
 /// Actions are split across threads, so this is the total number of actions
 const ACTIONS: u32 = 100;
@@ -125,6 +125,29 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             };
 
             database_test(WORKER_THREADS, DATABASE_THREADS, ACTIONS, action_generator);
+        })
+    });
+
+    c.bench_function("indexed list task", |b| {
+        b.iter(|| {
+            let action_generator = |thread_id: u32, index: u32| {
+                let full_name = format!("Full Name {}-{}", thread_id, index);
+                let email = format!("Email {}-{}", thread_id, index);
+
+                // Perform 5 adds, then the rest will be lists
+                if 1 > index {
+                    return Statement::Add(Person::new(full_name, Some(email)));
+                } else {
+                    // Full name is index, which means it will return 'NoResults' and this is a
+                    //  must faster path
+                    return Statement::List(Some(QueryPersonData {
+                        full_name: QueryMatch::Value("Will never match".to_string()),
+                        email: QueryMatch::Any,
+                    }));
+                }
+            };
+
+            database_test_task(WORKER_THREADS, DATABASE_THREADS, ACTIONS, action_generator);
         })
     });
 }

--- a/database/src/database/database.rs
+++ b/database/src/database/database.rs
@@ -370,7 +370,7 @@ mod tests {
         },
     };
 
-    use super::test_utils::database_test;
+    use super::test_utils::{database_test, database_test_task};
     use crate::database::commands::DatabaseCommandTransactionResponse;
     use crate::database::database::Database;
     use crate::model::statement::StatementResult;
@@ -585,38 +585,52 @@ mod tests {
     }
 
     mod bulk {
+        use crate::database::table::query::{QueryMatch, QueryPersonData};
+
         use super::*;
 
         #[test]
+        #[ignore]
         fn update() {
-            // 65k tps on M1 MBA
+            // Due to the RW Lock, writes are constant regardless of the number of threads (the lower the thread count the better)
+            // As a general note -- 75k TPS is really good, this is a 'some-what' durable commit as we're writing the WAL to disk
+            //  We are not technically flushing the WAL to disk, hence why
+            let setup_generator = |thread_id: u32| {
+                Statement::Add(person::Person {
+                    id: EntityId(thread_id.to_string()),
+                    full_name: "Test".to_string(),
+                    email: Some(format!("Email-{}", thread_id)),
+                })
+            };
+
             let action_generator = |thread: u32, index: u32| {
-                let id = EntityId(thread.to_string());
-                let full_name = format!("Full Name {}-{}", thread, index);
-                let email = format!("Email {}-{}", thread, index);
-
-                if index == 0 {
-                    return Statement::Add(Person {
-                        id,
-                        full_name,
-                        email: Some(email),
-                    });
-                }
-
                 return Statement::Update(
-                    id,
+                    EntityId(thread.to_string()),
                     UpdatePersonData {
-                        full_name: UpdateStatement::Set(full_name),
-                        email: UpdateStatement::Set(email),
+                        full_name: UpdateStatement::Set(index.to_string()),
+                        email: UpdateStatement::Set(format!("Email-{}{}", thread, index)),
                     },
                 );
             };
 
-            database_test(1, 1, 5, action_generator);
+            let metrics = database_test(5, 1, 200_000, action_generator, Some(setup_generator));
+
+            // ~82k s/ps on M1 MBA
+            println!("[Sync] Metrics: {:#?}", metrics);
+
+            let metrics =
+                database_test_task(4, 1, 200_000, action_generator, Some(setup_generator));
+
+            // ~82k s/ps on M1 MBA
+            println!("[Sync] Metrics: {:#?}", metrics);
         }
 
         #[test]
+        #[ignore]
         fn add() {
+            // Due to the RW Lock, writes are constant regardless of the number of threads (the lower the thread count the better)
+            // As a general note -- 75k TPS is really good, this is a 'some-what' durable commit as we're writing the WAL to disk
+            //  We are not technically flushing the WAL to disk, hence why
             let action_generator = |_, _| {
                 Statement::Add(person::Person {
                     id: EntityId::new(),
@@ -625,49 +639,171 @@ mod tests {
                 })
             };
 
-            database_test(1, 1, 5, action_generator);
+            let metrics = database_test(5, 1, 200_000, action_generator, None);
+
+            // ~75k s/ps on M1 MBA
+            println!("[Sync] Metrics: {:#?}", metrics);
+
+            let metrics = database_test_task(4, 1, 200_000, action_generator, None);
+
+            // ~75k s/ps on M1 MBA
+            println!("[Sync] Metrics: {:#?}", metrics);
         }
 
         #[test]
+        #[ignore]
         fn get() {
-            let action_generator = |thread_id: u32, index: u32| {
-                let id = EntityId(thread_id.to_string());
-                let full_name = format!("Full Name {}-{}", thread_id, index);
-                let email = format!("Email {}-{}", thread_id, index);
-
-                if index == 0 {
-                    return Statement::Add(Person {
-                        id,
-                        full_name,
-                        email: Some(email),
-                    });
-                }
-
-                return Statement::Get(id);
+            // Due to the RW Lock allows scaling, scaling reads scales logarithmically with the number of threads
+            let setup_generator = |thread_id: u32| {
+                Statement::Add(person::Person {
+                    id: EntityId(thread_id.to_string()),
+                    full_name: "Test".to_string(),
+                    email: Some(Uuid::new_v4().to_string()),
+                })
             };
 
-            database_test(1, 1, 5, action_generator);
+            let action_generator = |thread_id: u32, _: u32| {
+                return Statement::Get(EntityId(thread_id.to_string()));
+            };
+
+            let metrics = database_test(5, 3, 3_000_000, action_generator, Some(setup_generator));
+
+            // ~300k-400k s/ps on M1 MBA
+            println!("[Sync] Metrics: {:#?}", metrics);
+
+            let metrics =
+                database_test_task(4, 4, 3_000_000, action_generator, Some(setup_generator));
+
+            // ~600k-~900k s/ps on M1 MBA
+            println!("[Async] Metrics: {:#?}", metrics);
+        }
+
+        #[test]
+        #[ignore]
+        fn list() {
+            // Due to the RW Lock allows scaling, scaling reads scales logarithmically with the number of threads
+            let setup_generator = |thread_id: u32| {
+                Statement::Add(person::Person {
+                    id: EntityId(thread_id.to_string()),
+                    full_name: "Test".to_string(),
+                    email: Some(Uuid::new_v4().to_string()),
+                })
+            };
+
+            let action_generator = |_: u32, _: u32| {
+                return Statement::List(Some(QueryPersonData {
+                    full_name: QueryMatch::Any,
+                    email: QueryMatch::Any,
+                }));
+            };
+
+            let metrics = database_test(5, 3, 3_000_000, action_generator, Some(setup_generator));
+
+            // ~300k-400k s/ps on M1 MBA
+            println!("[Sync] Metrics: {:#?}", metrics);
+
+            let metrics =
+                database_test_task(3, 3, 3_000_000, action_generator, Some(setup_generator));
+
+            // ~600k-~900k s/ps on M1 MBA
+            println!("[Async] Metrics: {:#?}", metrics);
         }
     }
 }
 
 pub mod test_utils {
 
+    use num_format::ToFormattedString;
+
     use crate::{
         database::{database::Database, request_manager::TaskStatementResponse},
         model::statement::{Statement, StatementResult},
     };
-    use std::thread::{self, JoinHandle};
+    use std::{
+        fmt::Debug,
+        thread::{self, JoinHandle},
+        time::{Duration, Instant},
+    };
+
+    #[derive(Debug)]
+    pub enum Mode {
+        Single,
+        Task,
+    }
+
+    pub struct TestMetrics {
+        pub test_duration: Duration,
+        pub statements: u32,
+        pub mode: Mode,
+    }
+
+    impl TestMetrics {
+        pub fn new(mode: Mode, test_duration: Duration, statements: u32) -> Self {
+            Self {
+                mode,
+                test_duration,
+                statements,
+            }
+        }
+    }
+
+    impl Debug for TestMetrics {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let duration_ms = format!(
+                "{}ms",
+                self.test_duration
+                    .as_millis()
+                    .to_formatted_string(&num_format::Locale::en)
+            );
+
+            let statements_per_second =
+                ((self.statements as f64 / self.test_duration.as_secs_f64()) as u32)
+                    .to_formatted_string(&num_format::Locale::en);
+
+            f.debug_struct("TestMetrics")
+                .field("mode", &self.mode)
+                .field("test_duration", &duration_ms)
+                .field(
+                    "actions",
+                    &self.statements.to_formatted_string(&num_format::Locale::en),
+                )
+                .field("statements/s", &statements_per_second)
+                .finish()
+        }
+    }
 
     pub fn database_test(
         worker_threads: u32,
         database_threads: u32,
         actions: u32,
         action_generator: fn(u32, u32) -> Statement,
-    ) {
+        setup_generator: Option<fn(u32) -> Statement>,
+    ) -> TestMetrics {
         let rm = Database::new_test().run(database_threads);
 
+        // All setup is performed in the same thread, is synchronous, and is not included in the timer
+        if let Some(setup) = setup_generator {
+            for thread_id in 0..worker_threads {
+                let rm = rm.clone();
+
+                let statement = setup(thread_id);
+
+                let action_result = rm
+                    .send_single_statement(statement)
+                    .expect("Should not timeout");
+
+                match action_result {
+                    StatementResult::Single(_)
+                    | StatementResult::GetSingle(_)
+                    | StatementResult::List(_) => {}
+                    _ => panic!("Unexpected response type"),
+                }
+            }
+        }
+
         let mut sender_threads: Vec<JoinHandle<()>> = vec![];
+
+        let now = Instant::now();
 
         for thread_id in 0..worker_threads {
             let rm = rm.clone();
@@ -697,6 +833,8 @@ pub mod test_utils {
             thread.join().unwrap();
         }
 
+        let metrics = TestMetrics::new(Mode::Single, now.elapsed(), actions);
+
         // Allows database thread to successfully exit
         let shutdown_response = rm
             .clone()
@@ -707,6 +845,8 @@ pub mod test_utils {
             shutdown_response,
             "Successfully shutdown database".to_string()
         );
+
+        metrics
     }
 
     /// Sends N items into the channel and then awaits them all at the end. In theory this test
@@ -719,10 +859,33 @@ pub mod test_utils {
         database_threads: u32,
         actions: u32,
         action_generator: fn(u32, u32) -> Statement,
-    ) {
+        setup_generator: Option<fn(u32) -> Statement>,
+    ) -> TestMetrics {
         let rm = Database::new_test().run(database_threads);
 
         let mut sender_threads: Vec<JoinHandle<()>> = vec![];
+
+        // All setup is performed in the same thread, is synchronous, and is not included in the timer
+        if let Some(setup) = setup_generator {
+            for thread_id in 0..worker_threads {
+                let rm = rm.clone();
+
+                let statement = setup(thread_id);
+
+                let action_result = rm
+                    .send_single_statement(statement)
+                    .expect("Should not timeout");
+
+                match action_result {
+                    StatementResult::Single(_)
+                    | StatementResult::GetSingle(_)
+                    | StatementResult::List(_) => {}
+                    _ => panic!("Unexpected response type"),
+                }
+            }
+        }
+
+        let now = Instant::now();
 
         for thread_id in 0..worker_threads {
             let rm = rm.clone();
@@ -750,6 +913,8 @@ pub mod test_utils {
             thread.join().unwrap();
         }
 
+        let metrics = TestMetrics::new(Mode::Task, now.elapsed(), actions);
+
         // Allows database thread to successfully exit
         let shutdown_response = rm
             .clone()
@@ -760,5 +925,7 @@ pub mod test_utils {
             shutdown_response,
             "Successfully shutdown database".to_string()
         );
+
+        metrics
     }
 }

--- a/database/src/database/request_manager.rs
+++ b/database/src/database/request_manager.rs
@@ -40,16 +40,56 @@ pub enum RequestManagerError {
 }
 
 /// Goal of the request manager is to provide a simple interface for interacting with the database
+///
+/// The request manager has two categories of methods:
+/// 1. The level of abstraction (highest to lowest): Entity, Statement or Command
+/// 2. The level of synchronicity: Async (Task) or Sync
+///
+/// Sync:
+/// - Sync methods are the simplest to use, they send to the request and immediately put the thread to sleep until the response is received
+/// - Async methods are more complex to use, they send the request and return a future that can be awaited on
+///
+/// Abstraction level:
+/// - Entity, Provides Add, Update, Get, GetVersion, List methods for interacting with the database
+/// - Statement, allows sending a single statement or a transaction to the database
+/// - Command, allows sending control commands to the database, e.g. shutdown, reset, snapshot
 impl RequestManager {
     pub fn new(database_sender: flume::Sender<DatabaseCommandRequest>) -> Self {
         Self { database_sender }
     }
 
-    // -- Transaction Methods --
+    // -- Entity Methods: Async Task --
+    pub fn send_add_task(&self, person: Person) -> TaskAddResponse {
+        TaskAddResponse::send(self, person)
+    }
 
+    pub fn send_update_task(
+        &self,
+        id: EntityId,
+        person_update: UpdatePersonData,
+    ) -> TaskUpdateResponse {
+        TaskUpdateResponse::send(self, id, person_update)
+    }
+
+    pub fn send_get_task(&self, id: EntityId) -> TaskGetResponse {
+        TaskGetResponse::send(self, id)
+    }
+
+    pub fn send_get_version_task(
+        &self,
+        id: EntityId,
+        version_id: VersionId,
+    ) -> TaskGetVersionResponse {
+        TaskGetVersionResponse::send(self, id, version_id)
+    }
+
+    pub fn send_list_task(&self, query: Option<QueryPersonData>) -> TaskListResponse {
+        TaskListResponse::send(self, query)
+    }
+
+    // -- Entity Methods: Sync --
     pub fn send_add(&self, person: Person) -> Result<Person, RequestManagerError> {
-        let action_result = self.send_single_statement(Statement::Add(person))?;
-        return Ok(action_result.single());
+        self.send_add_task(person).get()
     }
 
     pub fn send_update(
@@ -57,13 +97,11 @@ impl RequestManager {
         id: EntityId,
         person_update: UpdatePersonData,
     ) -> Result<Person, RequestManagerError> {
-        let action_result = self.send_single_statement(Statement::Update(id, person_update))?;
-        return Ok(action_result.single());
+        self.send_update_task(id, person_update).get()
     }
 
     pub fn send_get(&self, id: EntityId) -> Result<Option<Person>, RequestManagerError> {
-        let action_result = self.send_single_statement(Statement::Get(id))?;
-        return Ok(action_result.get_single());
+        self.send_get_task(id).get()
     }
 
     pub fn send_get_version(
@@ -71,16 +109,14 @@ impl RequestManager {
         id: EntityId,
         version_id: VersionId,
     ) -> Result<Option<Person>, RequestManagerError> {
-        let action_result = self.send_single_statement(Statement::GetVersion(id, version_id))?;
-        return Ok(action_result.get_single());
+        self.send_get_version_task(id, version_id).get()
     }
 
     pub fn send_list(
         &self,
         query: Option<QueryPersonData>,
     ) -> Result<Vec<Person>, RequestManagerError> {
-        let action_result = self.send_single_statement(Statement::List(query))?;
-        return Ok(action_result.list());
+        self.send_list_task(query).get()
     }
 
     /// Convenience method to send a single statement to the database and returns the response
@@ -99,19 +135,15 @@ impl RequestManager {
     }
 
     /// Sends a set of statements to the database and returns the response
+    pub fn send_transaction_task(&self, statements: Vec<Statement>) -> TaskStatementResponse {
+        TaskStatementResponse::send(self, statements)
+    }
+
     pub fn send_transaction(
         &self,
         statements: Vec<Statement>,
     ) -> Result<Vec<StatementResult>, RequestManagerError> {
-        let command_result =
-            self.send_database_command(DatabaseCommand::Transaction(statements))?;
-
-        match command_result {
-            DatabaseCommandResponse::DatabaseCommandTransactionResponse(
-                DatabaseCommandTransactionResponse::Commit(action_results),
-            ) => Ok(action_results),
-            _ => panic!("Transaction commands should always return a commit or rollback"),
-        }
+        self.send_transaction_task(statements).get()
     }
 
     // -- Control Methods --
@@ -130,7 +162,6 @@ impl RequestManager {
     }
 
     // -- Internal methods --
-
     fn send_control(&self, control: Control) -> Result<String, RequestManagerError> {
         let command_result = self.send_database_command(DatabaseCommand::Control(control))?;
 
@@ -161,11 +192,30 @@ impl RequestManager {
 
         let response = response_receiver.recv_timeout(Duration::from_secs(10));
 
-        match response {
-            // Transaction commands
-            Ok(DatabaseCommandResponse::DatabaseCommandTransactionResponse(
-                transaction_response,
-            )) => match transaction_response {
+        map_response(response)
+    }
+
+    fn send_database_command_task(&self, database_request: DatabaseCommand) -> TaskCommandResponse {
+        let (response_sender, response_receiver) = oneshot::channel::<DatabaseCommandResponse>();
+
+        let request = DatabaseCommandRequest {
+            resolver: response_sender,
+            command: database_request,
+        };
+
+        self.database_sender.send(request).unwrap();
+
+        TaskCommandResponse::send(response_receiver)
+    }
+}
+
+fn map_response(
+    response: Result<DatabaseCommandResponse, oneshot::RecvTimeoutError>,
+) -> Result<DatabaseCommandResponse, RequestManagerError> {
+    match response {
+        // Transaction commands
+        Ok(DatabaseCommandResponse::DatabaseCommandTransactionResponse(transaction_response)) => {
+            match transaction_response {
                 DatabaseCommandTransactionResponse::Commit(statement_result) => {
                     Ok(DatabaseCommandResponse::DatabaseCommandTransactionResponse(
                         DatabaseCommandTransactionResponse::Commit(statement_result),
@@ -174,23 +224,282 @@ impl RequestManager {
                 DatabaseCommandTransactionResponse::Rollback(s) => {
                     Err(RequestManagerError::TransactionRollback(s))
                 }
-            },
-            // Control commands
-            Ok(DatabaseCommandResponse::DatabaseCommandControlResponse(control_response)) => {
-                match control_response {
-                    DatabaseCommandControlResponse::Success(s) => {
-                        Ok(DatabaseCommandResponse::DatabaseCommandControlResponse(
-                            DatabaseCommandControlResponse::Success(s),
-                        ))
-                    }
-                    DatabaseCommandControlResponse::Error(s) => {
-                        Err(RequestManagerError::DatabaseErrorStatus(s))
-                    }
+            }
+        }
+        // Control commands
+        Ok(DatabaseCommandResponse::DatabaseCommandControlResponse(control_response)) => {
+            match control_response {
+                DatabaseCommandControlResponse::Success(s) => {
+                    Ok(DatabaseCommandResponse::DatabaseCommandControlResponse(
+                        DatabaseCommandControlResponse::Success(s),
+                    ))
+                }
+                DatabaseCommandControlResponse::Error(s) => {
+                    Err(RequestManagerError::DatabaseErrorStatus(s))
                 }
             }
-            // Issues with the channel
-            Err(oneshot::RecvTimeoutError::Timeout) => Err(RequestManagerError::DatabaseTimeout),
-            Err(oneshot::RecvTimeoutError::Disconnected) => panic!("Processor exited"),
         }
+        // Issues with the channel
+        Err(oneshot::RecvTimeoutError::Timeout) => Err(RequestManagerError::DatabaseTimeout),
+        Err(oneshot::RecvTimeoutError::Disconnected) => panic!("Processor exited"),
+    }
+}
+
+fn send_request(
+    request_manager: &RequestManager,
+    statement: Vec<Statement>,
+) -> oneshot::Receiver<DatabaseCommandResponse> {
+    let (response_sender, response_receiver) = oneshot::channel::<DatabaseCommandResponse>();
+
+    let request = DatabaseCommandRequest {
+        resolver: response_sender,
+        command: DatabaseCommand::Transaction(statement),
+    };
+
+    request_manager.database_sender.send(request).unwrap();
+
+    response_receiver
+}
+
+fn get_statement(
+    response: oneshot::Receiver<DatabaseCommandResponse>,
+) -> Result<Vec<StatementResult>, RequestManagerError> {
+    let response = response.recv_timeout(Duration::from_secs(10));
+
+    let command_result = map_response(response)?;
+
+    match command_result {
+        DatabaseCommandResponse::DatabaseCommandTransactionResponse(
+            DatabaseCommandTransactionResponse::Commit(action_results),
+        ) => Ok(action_results),
+        _ => panic!("Transaction commands should always return a commit or rollback"),
+    }
+}
+
+pub struct TaskCommandResponse {
+    response: oneshot::Receiver<DatabaseCommandResponse>,
+}
+
+impl TaskCommandResponse {
+    fn send(response: oneshot::Receiver<DatabaseCommandResponse>) -> Self {
+        Self { response }
+    }
+
+    fn get(&self) -> Result<DatabaseCommandResponse, RequestManagerError> {
+        let response = self.response.recv_timeout(Duration::from_secs(10));
+
+        map_response(response)
+    }
+}
+
+pub struct TaskStatementResponse {
+    response: oneshot::Receiver<DatabaseCommandResponse>,
+}
+
+impl TaskStatementResponse {
+    fn send(request_manager: &RequestManager, statement: Vec<Statement>) -> Self {
+        Self {
+            response: send_request(request_manager, statement),
+        }
+    }
+
+    fn get(self) -> Result<Vec<StatementResult>, RequestManagerError> {
+        get_statement(self.response)
+    }
+}
+
+pub struct TaskAddResponse {
+    response: oneshot::Receiver<DatabaseCommandResponse>,
+}
+
+impl TaskAddResponse {
+    fn send(request_manager: &RequestManager, person: Person) -> Self {
+        Self {
+            response: send_request(request_manager, vec![Statement::Add(person)]),
+        }
+    }
+
+    fn get(self) -> Result<Person, RequestManagerError> {
+        get_statement(self.response).and_then(|mut action_result| {
+            Ok(action_result
+                .pop()
+                .expect("single a statement should generate single response")
+                .single())
+        })
+    }
+}
+
+pub struct TaskUpdateResponse {
+    response: oneshot::Receiver<DatabaseCommandResponse>,
+}
+
+impl TaskUpdateResponse {
+    fn send(
+        request_manager: &RequestManager,
+        id: EntityId,
+        person_update: UpdatePersonData,
+    ) -> Self {
+        Self {
+            response: send_request(request_manager, vec![Statement::Update(id, person_update)]),
+        }
+    }
+
+    fn get(self) -> Result<Person, RequestManagerError> {
+        get_statement(self.response).and_then(|mut action_result| {
+            Ok(action_result
+                .pop()
+                .expect("single a statement should generate single response")
+                .single())
+        })
+    }
+}
+
+pub struct TaskGetResponse {
+    response: oneshot::Receiver<DatabaseCommandResponse>,
+}
+
+impl TaskGetResponse {
+    fn send(request_manager: &RequestManager, id: EntityId) -> Self {
+        Self {
+            response: send_request(request_manager, vec![Statement::Get(id)]),
+        }
+    }
+
+    fn get(self) -> Result<Option<Person>, RequestManagerError> {
+        get_statement(self.response).and_then(|mut action_result| {
+            Ok(action_result
+                .pop()
+                .expect("single a statement should generate single response")
+                .get_single())
+        })
+    }
+}
+
+pub struct TaskGetVersionResponse {
+    response: oneshot::Receiver<DatabaseCommandResponse>,
+}
+
+impl TaskGetVersionResponse {
+    fn send(request_manager: &RequestManager, id: EntityId, version_id: VersionId) -> Self {
+        Self {
+            response: send_request(request_manager, vec![Statement::GetVersion(id, version_id)]),
+        }
+    }
+
+    fn get(self) -> Result<Option<Person>, RequestManagerError> {
+        get_statement(self.response).and_then(|mut action_result| {
+            Ok(action_result
+                .pop()
+                .expect("single a statement should generate single response")
+                .get_single())
+        })
+    }
+}
+
+pub struct TaskListResponse {
+    response: oneshot::Receiver<DatabaseCommandResponse>,
+}
+
+impl TaskListResponse {
+    fn send(request_manager: &RequestManager, query: Option<QueryPersonData>) -> Self {
+        Self {
+            response: send_request(request_manager, vec![Statement::List(query)]),
+        }
+    }
+
+    fn get(self) -> Result<Vec<Person>, RequestManagerError> {
+        get_statement(self.response).and_then(|mut action_result| {
+            Ok(action_result
+                .pop()
+                .expect("single a statement should generate single response")
+                .list())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use crate::{
+        consts::consts::EntityId,
+        database::{
+            commands::{DatabaseCommand, DatabaseCommandControlResponse, DatabaseCommandResponse},
+            database::Database,
+        },
+        model::{
+            person::Person,
+            statement::{Statement, StatementResult},
+        },
+    };
+
+    #[test]
+    fn sync() {
+        let request_manager = Database::new_test().run(1);
+
+        let action_result = request_manager
+            .send_single_statement(Statement::Add(Person {
+                id: EntityId::new(),
+                full_name: "Test".to_string(),
+                email: Some(Uuid::new_v4().to_string()),
+            }))
+            .expect("Should not timeout");
+
+        assert_eq!(action_result.single().full_name, "Test");
+    }
+
+    #[test]
+    fn task_command() {
+        let request_manager = Database::new_test().run(1);
+
+        let person = Person {
+            id: EntityId::new(),
+            full_name: "Test".to_string(),
+            email: Some(Uuid::new_v4().to_string()),
+        };
+
+        let task = request_manager.send_database_command_task(DatabaseCommand::Transaction(vec![
+            Statement::Add(person.clone()),
+        ]));
+
+        let action_result = task.get().expect("Should not timeout");
+
+        assert_eq!(
+            action_result,
+            DatabaseCommandResponse::transaction_commit(vec![StatementResult::Single(person)])
+        );
+    }
+
+    #[test]
+    fn task_statement() {
+        let request_manager = Database::new_test().run(1);
+
+        let task = request_manager.send_transaction_task(vec![Statement::Add(Person {
+            id: EntityId::new(),
+            full_name: "Test".to_string(),
+            email: Some(Uuid::new_v4().to_string()),
+        })]);
+
+        let action_result = task.get().expect("Should not timeout");
+
+        assert_eq!(action_result.len(), 1);
+    }
+
+    #[test]
+    fn task_add() {
+        let request_manager = Database::new_test().run(1);
+
+        let person = Person {
+            id: EntityId::new(),
+            full_name: "Test".to_string(),
+            email: Some(Uuid::new_v4().to_string()),
+        };
+
+        let added_person = request_manager
+            .send_add_task(person.clone())
+            .get()
+            .expect("should not timeout");
+
+        assert_eq!(added_person, person);
     }
 }


### PR DESCRIPTION
Changes:
- Adds an 'async' task like API to the request manage. This is useful for sending multiple requests at the same time and then awaiting on the result.
- Due to all the challenges with using benchmark to test multiple database threads, there are a set of performance based unit tests