### PR TITLE
Improved benchmarks

### DIFF
--- a/database/benches/my_benchmark.rs
+++ b/database/benches/my_benchmark.rs
@@ -1,5 +1,3 @@
-use std::{thread, time::Duration};
-
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use database::{
     consts::consts::EntityId,

--- a/database/benches/my_benchmark.rs
+++ b/database/benches/my_benchmark.rs
@@ -10,6 +10,7 @@ use database::{
     },
     model::{person::Person, statement::Statement},
 };
+use uuid::Uuid;
 
 // Number of threads to use for the database
 // Due to the RW lock, additional write threads do not improve performance (contention will cause slow down),
@@ -18,6 +19,8 @@ const DATABASE_THREADS_WRITE: u32 = 1;
 const DATABASE_THREADS_READ: u32 = 3;
 
 const SAMPLE_SIZE: [u64; 3] = [100, 1_000, 10_000];
+
+const INPUT_SIZE: criterion::BatchSize = criterion::BatchSize::SmallInput;
 
 /*
     How this bench is configured:
@@ -41,15 +44,15 @@ pub fn add_benchmark(c: &mut Criterion) {
             b.iter_batched(
                 || rm_add.clone(),
                 |rm_add| {
-                    run_action(rm_add, size.try_into().unwrap(), size, |id, index| {
+                    run_action(rm_add, size.try_into().unwrap(), size, |_, index| {
                         return Statement::Add(Person {
-                            id: EntityId(format!("{}{}", id, index)),
+                            id: EntityId(Uuid::new_v4().to_string()),
                             full_name: index.to_string(),
                             email: None,
                         });
                     });
                 },
-                criterion::BatchSize::SmallInput,
+                INPUT_SIZE,
             )
         });
     }
@@ -89,7 +92,7 @@ pub fn update_benchmark(c: &mut Criterion) {
                         );
                     });
                 },
-                criterion::BatchSize::SmallInput,
+                INPUT_SIZE,
             )
         });
     }
@@ -123,7 +126,7 @@ pub fn get_benchmark(c: &mut Criterion) {
                         Statement::Get(EntityId("get".to_string()))
                     });
                 },
-                criterion::BatchSize::SmallInput,
+                INPUT_SIZE,
             )
         });
     }
@@ -154,7 +157,7 @@ pub fn list_benchmark(c: &mut Criterion) {
                         }))
                     });
                 },
-                criterion::BatchSize::SmallInput,
+                INPUT_SIZE,
             )
         });
     }

--- a/database/src/database/request_manager.rs
+++ b/database/src/database/request_manager.rs
@@ -190,7 +190,8 @@ impl RequestManager {
         //  on the response_receiver once it's finished processing it's request
         self.database_sender.send(request).unwrap();
 
-        let response = response_receiver.recv_timeout(Duration::from_secs(30));
+        // If the database is large it can take > 30 seconds to reset
+        let response = response_receiver.recv_timeout(Duration::from_secs(60));
 
         map_response(response)
     }

--- a/database/src/database/request_manager.rs
+++ b/database/src/database/request_manager.rs
@@ -150,6 +150,8 @@ impl RequestManager {
 
     /// Sends a shutdown request to the database and returns the database's response
     pub fn send_shutdown_request(&self) -> Result<String, RequestManagerError> {
+        // TODO: Shutdown may not work if there are multiple database threads.
+        //  will have to send N shutdown requests for each database thread.
         return self.send_control(Control::Shutdown);
     }
 


### PR DESCRIPTION
- Added improvements to benchmarking
   - The database is created once per test suite
   - Is cleaned up at the end of the suite
- Defines different file write modes, defaults to none for benchmarking
- To allow for database options to become accessible across the entire DB, we pass database options around instead of individual properties

<img width="1060" alt="image" src="https://github.com/Compulsed/lineagedb/assets/1109278/905d2b8b-2ca0-44f2-9d87-2e2b4e9a5ed6">

Max read speeds:
~1.2 million reads per second
~833 nanoseconds per read

For a read, we need to do the following:
1. Create a statement (GET for X string -- heap allocation)
1. Send a response over the flume channel
1. Pull a message off of the flume channel
1. Acquire the R/W lock
1. Locate the row in the hashmap
1. Get the latest version for that row
1. Generate response (copy data from row)
1. Release the R/W lock
1. Send a response back via the one-shot channel
1. Read the response