### PR TITLE
Feat/snapshot querying

### DIFF
--- a/clients/graphql/src/main.rs
+++ b/clients/graphql/src/main.rs
@@ -20,7 +20,6 @@ use database::{
     },
 };
 use juniper::http::{graphiql::graphiql_source, GraphQLRequest};
-use std::sync::Mutex;
 use std::{io, sync::Arc};
 
 use crate::schema::{create_schema, GraphQLContext, Schema};
@@ -43,7 +42,7 @@ async fn graphql(
     let request_manager = request_manager_ref.as_ref();
 
     let graphql_context = GraphQLContext {
-        request_manager: Mutex::new(request_manager.clone()),
+        request_manager: request_manager.clone(),
     };
 
     let user = data.execute(&schema, &graphql_context).await;

--- a/clients/graphql/src/schema.rs
+++ b/clients/graphql/src/schema.rs
@@ -143,6 +143,18 @@ impl QueryRoot {
 
         return Ok(result);
     }
+
+    fn database_info(context: &'db GraphQLContext) -> FieldResult<Vec<String>> {
+        let database = context.request_manager.lock().unwrap();
+
+        let database_info = database
+            .send_info_request()?
+            .into_iter()
+            .map(|r| format!("[{}] {}", r.0, r.1))
+            .collect();
+
+        return Ok(database_info);
+    }
 }
 
 pub struct MutationRoot;

--- a/clients/graphql/src/schema.rs
+++ b/clients/graphql/src/schema.rs
@@ -1,5 +1,5 @@
 use database::{
-    consts::consts::{EntityId, TransactionId},
+    consts::consts::EntityId,
     database::{
         commands::{SnapshotTimestamp, TransactionContext},
         request_manager::RequestManager,

--- a/clients/tcp-server/src/main.rs
+++ b/clients/tcp-server/src/main.rs
@@ -5,6 +5,7 @@ use std::thread;
 
 use clap::Parser;
 use database::consts::consts::EntityId;
+use database::database::commands::TransactionContext;
 use database::database::database::{Database, DatabaseOptions};
 use database::database::table::row::{UpdatePersonData, UpdateStatement};
 use database::model::person::Person;
@@ -82,7 +83,7 @@ fn main() {
 
                             if let Some(statement) = statement {
                                 let response = request_manager
-                                    .send_single_statement(statement)
+                                    .send_single_statement(statement, TransactionContext::default())
                                     .expect("Should not timeout");
 
                                 writeln!(stream, "{:#?}", response).unwrap();

--- a/database/benches/database.rs
+++ b/database/benches/database.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use database::{
     consts::consts::{EntityId, TransactionId},
-    database::database::{ApplyMode, Database},
+    database::database::{test_utils::apply_transaction_at_next_timestamp, Database},
     model::{person::Person, statement::Statement},
 };
 use std::sync::{mpsc::channel, Arc};
@@ -45,7 +45,7 @@ pub fn database_add_benchmark(c: &mut Criterion) {
 
                                 let statements = vec![Statement::Add(person.clone())];
 
-                                database.apply_transaction(statements, ApplyMode::Restore);
+                                let _ = apply_transaction_at_next_timestamp(&database, statements);
                             }
 
                             test_tx.send(1).expect("Should not timeout");
@@ -81,7 +81,7 @@ pub fn database_get_benchmark(c: &mut Criterion) {
 
             let statements = vec![Statement::Add(person.clone())];
 
-            let _ = database.apply_transaction(statements, ApplyMode::Restore);
+            let _ = apply_transaction_at_next_timestamp(&database, statements);
         }
 
         group.throughput(Throughput::Elements(SAMPLE_SIZE));

--- a/database/benches/request_manager.rs
+++ b/database/benches/request_manager.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use database::{
     consts::consts::EntityId,
     database::{
-        commands::ShutdownRequest,
+        commands::{ShutdownRequest, TransactionContext},
         database::{test_utils::run_action, Database},
     },
     model::{
@@ -127,8 +127,11 @@ pub fn rm_get_benchmark(c: &mut Criterion) {
                 email: None,
             };
 
-            rm.send_single_statement(Statement::Add(person.clone()))
-                .expect("Should not timeout");
+            rm.send_single_statement(
+                Statement::Add(person.clone()),
+                TransactionContext::default(),
+            )
+            .expect("Should not timeout");
         }
 
         group.throughput(Throughput::Elements(SAMPLE_SIZE));
@@ -195,8 +198,11 @@ pub fn rm_hybrid_benchmark(c: &mut Criterion) {
                 email: None,
             };
 
-            rm.send_single_statement(Statement::Add(person.clone()))
-                .expect("Should not timeout");
+            rm.send_single_statement(
+                Statement::Add(person.clone()),
+                TransactionContext::default(),
+            )
+            .expect("Should not timeout");
         }
 
         group.throughput(Throughput::Elements(SAMPLE_SIZE));

--- a/database/src/consts/consts.rs
+++ b/database/src/consts/consts.rs
@@ -18,6 +18,10 @@ impl TransactionId {
         TransactionId(1)
     }
 
+    pub fn new_highest_transaction() -> TransactionId {
+        TransactionId(usize::MAX)
+    }
+
     pub fn increment(&self) -> TransactionId {
         TransactionId(self.0 + 1)
     }

--- a/database/src/consts/consts.rs
+++ b/database/src/consts/consts.rs
@@ -23,6 +23,12 @@ impl TransactionId {
     }
 }
 
+impl From<i32> for TransactionId {
+    fn from(transaction_id: i32) -> TransactionId {
+        TransactionId(transaction_id.try_into().unwrap())
+    }
+}
+
 impl fmt::Display for TransactionId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)

--- a/database/src/database/commands.rs
+++ b/database/src/database/commands.rs
@@ -60,6 +60,8 @@ pub enum DatabaseCommandControlResponse {
     Success(String),
     /// Command has failed, returns a message for why it failed
     Error(String),
+    /// Returns a tuple, used for database information
+    Info(Vec<(String, String)>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -72,6 +74,12 @@ impl DatabaseCommandResponse {
     pub fn control_success(message: &str) -> Self {
         DatabaseCommandResponse::DatabaseCommandControlResponse(
             DatabaseCommandControlResponse::Success(message.to_string()),
+        )
+    }
+
+    pub fn control_info(info: Vec<(String, String)>) -> Self {
+        DatabaseCommandResponse::DatabaseCommandControlResponse(
+            DatabaseCommandControlResponse::Info(info),
         )
     }
 
@@ -118,6 +126,8 @@ pub enum Control {
     ResetDatabase,
     /// Pauses the database so that we can perform certain operations
     PauseDatabase(flume::Receiver<()>),
+    /// Provides the caller some KV information on database stats
+    DatabaseStats,
 }
 
 pub enum SnapshotTimestamp {

--- a/database/src/database/commands.rs
+++ b/database/src/database/commands.rs
@@ -1,4 +1,7 @@
-use crate::model::statement::{Statement, StatementResult};
+use crate::{
+    consts::consts::TransactionId,
+    model::statement::{Statement, StatementResult},
+};
 
 /// Database commands are how we interact with the database, they are how we ask the database to run a transaction, shutdown, etc
 ///
@@ -117,7 +120,35 @@ pub enum Control {
     PauseDatabase(flume::Receiver<()>),
 }
 
+pub enum SnapshotTimestamp {
+    /// The transaction id that the statement is running on
+    AtTransactionId(TransactionId),
+    /// Use the latest transaction id
+    Latest,
+}
+
+/// Information about the transaction that is being run
+pub struct TransactionContext {
+    /// The snapshot id that the transaction is running on. If none, use the latest transaction id
+    pub snapshot_timestamp: SnapshotTimestamp,
+}
+
+impl TransactionContext {
+    pub fn new(snapshot_timestamp: SnapshotTimestamp) -> Self {
+        TransactionContext { snapshot_timestamp }
+    }
+}
+
+impl Default for TransactionContext {
+    fn default() -> Self {
+        TransactionContext {
+            snapshot_timestamp: SnapshotTimestamp::Latest,
+        }
+    }
+}
+
 pub struct DatabaseCommandRequest {
     pub resolver: oneshot::Sender<DatabaseCommandResponse>,
     pub command: DatabaseCommand,
+    pub transaction_context: TransactionContext,
 }

--- a/database/src/database/database.rs
+++ b/database/src/database/database.rs
@@ -195,7 +195,7 @@ impl Database {
                 .clone();
 
             log::info!(
-                "[Thread: {}. TxId: {}] ()Received request: {}",
+                "[Thread: {}. TxId: {}] Received request: {}",
                 thread_id,
                 transaction_timestamp,
                 command.log_format()

--- a/database/src/database/database.rs
+++ b/database/src/database/database.rs
@@ -1,7 +1,6 @@
 use std::{path::PathBuf, sync::Arc, thread, time::Instant};
 
 use num_format::{Locale, ToFormattedString};
-use tokio_postgres::row;
 use uuid::Uuid;
 
 use crate::{
@@ -196,7 +195,7 @@ impl Database {
                 .clone();
 
             log::info!(
-                "[Thread: {}. TxId: {}] Received request: {}",
+                "[Thread: {}. TxId: {}] ()Received request: {}",
                 thread_id,
                 transaction_timestamp,
                 command.log_format()

--- a/database/src/database/request_manager.rs
+++ b/database/src/database/request_manager.rs
@@ -218,6 +218,19 @@ impl RequestManager {
         return self.send_control(Control::ResetDatabase);
     }
 
+    pub fn send_info_request(&self) -> Result<Vec<(String, String)>, RequestManagerError> {
+        let command_result =
+            self.send_database_command(DatabaseCommand::Control(Control::DatabaseStats))?;
+
+        // TODO: Clean this logic up, as we are now able to return success, info and error
+        match command_result {
+            DatabaseCommandResponse::DatabaseCommandControlResponse(
+                DatabaseCommandControlResponse::Info(i),
+            ) => Ok(i),
+            _ => panic!("Controls should always return a success, info or error status"),
+        }
+    }
+
     pub fn send_snapshot_request(&self) -> Result<String, RequestManagerError> {
         return self.send_control(Control::SnapshotDatabase);
     }
@@ -230,7 +243,7 @@ impl RequestManager {
             DatabaseCommandResponse::DatabaseCommandControlResponse(
                 DatabaseCommandControlResponse::Success(s),
             ) => Ok(s),
-            _ => panic!("Controls should always return a success or error status"),
+            _ => panic!("Controls should always return a success, info or error status"),
         }
     }
 
@@ -311,6 +324,11 @@ fn map_response(
                 DatabaseCommandControlResponse::Success(s) => {
                     Ok(DatabaseCommandResponse::DatabaseCommandControlResponse(
                         DatabaseCommandControlResponse::Success(s),
+                    ))
+                }
+                DatabaseCommandControlResponse::Info(s) => {
+                    Ok(DatabaseCommandResponse::DatabaseCommandControlResponse(
+                        DatabaseCommandControlResponse::Info(s),
                     ))
                 }
                 DatabaseCommandControlResponse::Error(s) => {

--- a/database/src/database/request_manager.rs
+++ b/database/src/database/request_manager.rs
@@ -67,8 +67,6 @@ impl RequestManager {
     fn get_sender(&self) -> &flume::Sender<DatabaseCommandRequest> {
         let mut rng = thread_rng();
 
-        // return &self.database_sender[0];
-
         self.database_sender
             .choose(&mut rng)
             .expect("Should have at least one sender")

--- a/database/src/database/table/row.rs
+++ b/database/src/database/table/row.rs
@@ -222,15 +222,30 @@ impl PersonRow {
         return (version, drop_row);
     }
 
-    pub fn person_at_version(&self, version_id: VersionId) -> Option<Person> {
-        self.at_version(version_id)
+    pub fn person_at_version(
+        &self,
+        version_id: VersionId,
+        transaction_id: &TransactionId,
+    ) -> Option<Person> {
+        self.at_version(version_id, transaction_id)
             .and_then(|version| version.get_person())
     }
 
-    pub fn at_version(&self, version_id: VersionId) -> Option<PersonVersion> {
+    pub fn at_version(
+        &self,
+        version_id: VersionId,
+        transaction_id: &TransactionId,
+    ) -> Option<PersonVersion> {
+        // TODO: Filter out the versions that are not committed?
+        let versions_at_snapshot = self
+            .versions
+            .iter()
+            .filter(|version| &version.transaction_id <= transaction_id)
+            .collect::<Vec<&PersonVersion>>();
+
         // Versions are 1 indexed, subtract 1 to get the correct vector index
-        match self.versions.get(version_id.to_number() - 1) {
-            Some(version) => Some(version.clone()),
+        match versions_at_snapshot.get(version_id.to_number() - 1) {
+            Some(version) => Some((*version).clone()),
             None => None,
         }
     }

--- a/database/src/database/table/table.rs
+++ b/database/src/database/table/table.rs
@@ -81,7 +81,11 @@ impl PersonTable {
         let action_result = match statement {
             Statement::Get(id) => {
                 let person = match &self.person_rows.get(&id) {
-                    Some(person_data) => person_data.value().read().unwrap().current_state(),
+                    Some(person_data) => person_data
+                        .value()
+                        .read()
+                        .unwrap()
+                        .at_transaction_id(&transaction_id),
                     None => return Err(ApplyErrors::CannotGetDoesNotExist(id)),
                 };
 
@@ -93,7 +97,7 @@ impl PersonTable {
                         .value()
                         .read()
                         .unwrap()
-                        .person_at_version(version),
+                        .person_at_version(version, transaction_id),
 
                     None => return Err(ApplyErrors::CannotGetAtVersionDoesNotExist(id, version)),
                 };
@@ -555,111 +559,286 @@ mod tests {
         }
     }
 
-    pub fn list_test(
-        statements: Vec<Statement>,
-        list_statement: Statement,
-        compare_to: Vec<Person>,
-    ) -> () {
-        let table = PersonTable::new();
-        let mut next_transaction_id = TransactionId::new_first_transaction();
+    mod versioning {
+        use super::*;
 
-        for statement in statements {
-            table.apply(statement, next_transaction_id.clone()).unwrap();
-            next_transaction_id = next_transaction_id.increment();
+        /// Tests are broken up into three categories:
+        /// - Get Statement
+        /// - Row data, normally would not depend on private fields, though MVCC has complex logic so this makes it easier to test
+        mod row_data {
+            #[allow(
+                unused_imports,
+                reason = "I think there is a bug here where it thinks the imports are unused, but they are required"
+            )]
+            use super::*;
+
+            #[test]
+            fn adding_item_creates_version_at_v1() {
+                // Given an empty table
+                let mut table = PersonTable::new();
+
+                // When we add an item
+                let (person, _) = add_test_person_to_empty_database(&mut table);
+
+                // Then we should have: one version, at version 1, with transaction id 1
+                let person_row = table.get_version_row_test(&person.id);
+
+                assert_eq!(person_row.version_count(), 1);
+
+                assert_eq!(
+                    person_row.at_version(VersionId(1), &TransactionId::new_highest_transaction()),
+                    Some(PersonVersion {
+                        id: person.id.clone(),
+                        state: PersonVersionState::State(person),
+                        version: VersionId(1),
+                        transaction_id: TransactionId(1),
+                    })
+                );
+            }
+
+            #[test]
+            fn adding_then_updating_creates_version_v2() {
+                // Given an empty table
+                let mut table = PersonTable::new();
+
+                // When we add an item
+                let (person, next_transaction_id) = add_test_person_to_empty_database(&mut table);
+
+                // And we update the item
+                let (updated_person, _) =
+                    update_test_person(&mut table, &person, next_transaction_id);
+
+                // Then we should have: two versions, at version 1 and 2, with transaction id 1 and 2
+                let person_row = table.get_version_row_test(&person.id);
+
+                assert_eq!(person_row.version_count(), 2);
+
+                assert_eq!(
+                    person_row.at_version(VersionId(1), &TransactionId::new_highest_transaction()),
+                    Some(PersonVersion {
+                        id: person.id.clone(),
+                        state: PersonVersionState::State(person),
+                        version: VersionId(1),
+                        transaction_id: TransactionId(1),
+                    })
+                );
+
+                assert_eq!(
+                    person_row.at_version(VersionId(2), &TransactionId::new_highest_transaction()),
+                    Some(PersonVersion {
+                        id: updated_person.id.clone(),
+                        state: PersonVersionState::State(updated_person),
+                        version: VersionId(2),
+                        transaction_id: TransactionId(2),
+                    })
+                );
+            }
+
+            #[test]
+            fn adding_then_updating_then_deleting_creates_version_v3() {
+                // Given an empty table
+                let mut table = PersonTable::new();
+
+                // When we add an item
+                let (add_person, next_transaction_id) =
+                    add_test_person_to_empty_database(&mut table);
+
+                // And we update the item
+                let (updated_person, next_transaction_id) =
+                    update_test_person(&mut table, &add_person, next_transaction_id);
+
+                // And we delete the item
+                let _ = delete_test_person(&mut table, &updated_person.id, next_transaction_id);
+
+                // Then we should have: two versions, at version 1 and 2, with transaction id 1 and 2
+                let person_row = table.get_version_row_test(&updated_person.id);
+
+                assert_eq!(person_row.version_count(), 3);
+
+                assert_eq!(
+                    person_row.at_version(VersionId(1), &TransactionId::new_highest_transaction()),
+                    Some(PersonVersion {
+                        id: add_person.id.clone(),
+                        state: PersonVersionState::State(add_person),
+                        version: VersionId(1),
+                        transaction_id: TransactionId(1),
+                    })
+                );
+
+                assert_eq!(
+                    person_row.at_version(VersionId(2), &TransactionId::new_highest_transaction()),
+                    Some(PersonVersion {
+                        id: updated_person.id.clone(),
+                        state: PersonVersionState::State(updated_person.clone()),
+                        version: VersionId(2),
+                        transaction_id: TransactionId(2),
+                    })
+                );
+
+                assert_eq!(
+                    person_row.at_version(VersionId(3), &TransactionId::new_highest_transaction()),
+                    Some(PersonVersion {
+                        id: updated_person.id.clone(),
+                        state: PersonVersionState::Delete,
+                        version: VersionId(3),
+                        transaction_id: TransactionId(3),
+                    })
+                );
+            }
         }
 
-        let mut list_results = table
-            .apply(list_statement, next_transaction_id)
-            .unwrap()
-            .list();
+        mod get_statement {
+            #[allow(
+                unused_imports,
+                reason = "I think there is a bug here where it thinks the imports are unused, but they are required"
+            )]
+            use super::*;
 
-        let mut sort_compare_to = compare_to;
+            #[test]
+            fn add_then_get_person_at_version() {
+                // Given an empty table
+                let mut table = PersonTable::new();
 
-        sort_list(&mut list_results);
-        sort_list(&mut sort_compare_to);
+                // When we add an item
+                let (person, next_transaction_id) = add_test_person_to_empty_database(&mut table);
 
-        assert_eq!(&list_results, &sort_compare_to);
+                // Then we should be able to get the item at version 1
+                let person_v1 = get_test_person_at_version(
+                    &mut table,
+                    &person.id,
+                    &VersionId(1),
+                    next_transaction_id,
+                )
+                .expect("should have person");
+
+                assert_eq!(&person_v1, &person);
+            }
+
+            #[test]
+            fn add_update_then_get_person_at_version() {
+                // Given an empty table
+                let mut table = PersonTable::new();
+
+                // When we add an item
+                let (person, next_transaction_id) = add_test_person_to_empty_database(&mut table);
+
+                // And we update the item
+                let (updated_person, next_transaction_id) =
+                    update_test_person(&mut table, &person, next_transaction_id);
+
+                // Then we should be able to get the item at version 1
+                let person_v1 = get_test_person_at_version(
+                    &mut table,
+                    &person.id,
+                    &VersionId(1),
+                    next_transaction_id.clone(),
+                )
+                .expect("should have person");
+
+                assert_eq!(&person_v1, &person);
+
+                // Then we should be able to get the item at version 2
+                let person_v2 = get_test_person_at_version(
+                    &mut table,
+                    &person.id,
+                    &VersionId(2),
+                    next_transaction_id.clone(),
+                )
+                .expect("should have person");
+
+                assert_eq!(&person_v2, &updated_person);
+            }
+
+            #[test]
+            fn add_update_delete_then_get_person_at_version() {
+                // Given an empty table
+                let mut table = PersonTable::new();
+
+                // When we add an item
+                let (person, next_transaction_id) = add_test_person_to_empty_database(&mut table);
+
+                // And we update the item
+                let (updated_person, next_transaction_id) =
+                    update_test_person(&mut table, &person, next_transaction_id);
+
+                // And we delete the item
+                let next_transaction_id =
+                    delete_test_person(&mut table, &person.id, next_transaction_id);
+
+                // Then we should be able to get the item at version 1
+                let person_v1 = get_test_person_at_version(
+                    &mut table,
+                    &person.id,
+                    &VersionId(1),
+                    next_transaction_id.clone(),
+                )
+                .expect("should have person");
+
+                assert_eq!(&person_v1, &person);
+
+                // Then we should be able to get the item at version 2
+                let person_v2 = get_test_person_at_version(
+                    &mut table,
+                    &person.id,
+                    &VersionId(2),
+                    next_transaction_id.clone(),
+                )
+                .expect("should have person");
+
+                assert_eq!(&person_v2, &updated_person);
+
+                // Then we should NOT be able to get the item at version 3
+                let person_v3 = get_test_person_at_version(
+                    &mut table,
+                    &person.id,
+                    &VersionId(3),
+                    next_transaction_id.clone(),
+                );
+
+                assert!(person_v3.is_none());
+            }
+        }
     }
-}
 
-mod versioning {
-    use crate::database::table::row::UpdatePersonData;
-
-    use super::*;
-
-    /// Tests are broken up into three categories:
-    /// - Get Statement
-    /// - Row data, normally would not depend on private fields, though MVCC has complex logic so this makes it easier to test
-    mod row_data {
-        #[allow(
-            unused_imports,
-            reason = "I think there is a bug here where it thinks the imports are unused, but they are required"
-        )]
+    mod snapshots {
         use super::*;
 
         #[test]
-        fn adding_item_creates_version_at_v1() {
+        pub fn get_right_item_returned_for_snapshot_id() {
             // Given an empty table
             let mut table = PersonTable::new();
 
             // When we add an item
-            let (person, _) = add_test_person_to_empty_database(&mut table);
-
-            // Then we should have: one version, at version 1, with transaction id 1
-            let person_row = table.get_version_row_test(&person.id);
-
-            assert_eq!(person_row.version_count(), 1);
-
-            assert_eq!(
-                person_row.at_version(VersionId(1)),
-                Some(PersonVersion {
-                    id: person.id.clone(),
-                    state: PersonVersionState::State(person),
-                    version: VersionId(1),
-                    transaction_id: TransactionId(1),
-                })
-            );
-        }
-
-        #[test]
-        fn adding_then_updating_creates_version_v2() {
-            // Given an empty table
-            let mut table = PersonTable::new();
-
-            // When we add an item
-            let (person, next_transaction_id) = add_test_person_to_empty_database(&mut table);
+            let (expected_added_person, next_transaction_id) =
+                add_test_person_to_empty_database(&mut table);
 
             // And we update the item
-            let (updated_person, _) = update_test_person(&mut table, &person, next_transaction_id);
-
-            // Then we should have: two versions, at version 1 and 2, with transaction id 1 and 2
-            let person_row = table.get_version_row_test(&person.id);
-
-            assert_eq!(person_row.version_count(), 2);
-
-            assert_eq!(
-                person_row.at_version(VersionId(1)),
-                Some(PersonVersion {
-                    id: person.id.clone(),
-                    state: PersonVersionState::State(person),
-                    version: VersionId(1),
-                    transaction_id: TransactionId(1),
-                })
+            let (expected_updated_person, _) = update_test_person(
+                &mut table,
+                &expected_added_person,
+                next_transaction_id.clone(),
             );
 
-            assert_eq!(
-                person_row.at_version(VersionId(2)),
-                Some(PersonVersion {
-                    id: updated_person.id.clone(),
-                    state: PersonVersionState::State(updated_person),
-                    version: VersionId(2),
-                    transaction_id: TransactionId(2),
-                })
-            );
+            // We should be able to query the person we added
+            let actual_added_person = get_test_person(
+                &mut table,
+                &expected_added_person.id,
+                TransactionId::new_first_transaction(),
+            )
+            .expect("should have person");
+
+            assert_eq!(&expected_added_person, &actual_added_person);
+
+            // When we query v2 at snapshot 1, we should not get a result because the update happened after the snapshot
+            let actual_updated_person =
+                get_test_person(&mut table, &actual_added_person.id, next_transaction_id)
+                    .expect("should have person");
+
+            assert_eq!(&expected_updated_person, &actual_updated_person);
         }
 
         #[test]
-        fn adding_then_updating_then_deleting_creates_version_v3() {
+        pub fn get_version_right_item_returned_for_snapshot_id() {
             // Given an empty table
             let mut table = PersonTable::new();
 
@@ -667,158 +846,55 @@ mod versioning {
             let (add_person, next_transaction_id) = add_test_person_to_empty_database(&mut table);
 
             // And we update the item
-            let (updated_person, next_transaction_id) =
-                update_test_person(&mut table, &add_person, next_transaction_id);
+            let _ = update_test_person(&mut table, &add_person, next_transaction_id);
 
-            // And we delete the item
-            let _ = delete_test_person(&mut table, &updated_person.id, next_transaction_id);
-
-            // Then we should have: two versions, at version 1 and 2, with transaction id 1 and 2
-            let person_row = table.get_version_row_test(&updated_person.id);
-
-            assert_eq!(person_row.version_count(), 3);
-
-            assert_eq!(
-                person_row.at_version(VersionId(1)),
-                Some(PersonVersion {
-                    id: add_person.id.clone(),
-                    state: PersonVersionState::State(add_person),
-                    version: VersionId(1),
-                    transaction_id: TransactionId(1),
-                })
-            );
-
-            assert_eq!(
-                person_row.at_version(VersionId(2)),
-                Some(PersonVersion {
-                    id: updated_person.id.clone(),
-                    state: PersonVersionState::State(updated_person.clone()),
-                    version: VersionId(2),
-                    transaction_id: TransactionId(2),
-                })
-            );
-
-            assert_eq!(
-                person_row.at_version(VersionId(3)),
-                Some(PersonVersion {
-                    id: updated_person.id.clone(),
-                    state: PersonVersionState::Delete,
-                    version: VersionId(3),
-                    transaction_id: TransactionId(3),
-                })
-            );
-        }
-    }
-
-    mod get_statement {
-        #[allow(
-            unused_imports,
-            reason = "I think there is a bug here where it thinks the imports are unused, but they are required"
-        )]
-        use super::*;
-
-        #[test]
-        fn add_then_get_person_at_version() {
-            // Given an empty table
-            let mut table = PersonTable::new();
-
-            // When we add an item
-            let (person, next_transaction_id) = add_test_person_to_empty_database(&mut table);
-
-            // Then we should be able to get the item at version 1
-            let person_v1 = get_test_person_at_version(
+            // When we query v1 at snapshot 1, we should get a result
+            let _ = get_test_person_at_version(
                 &mut table,
-                &person.id,
+                &add_person.id,
                 &VersionId(1),
-                next_transaction_id,
+                TransactionId::new_first_transaction(),
             )
             .expect("should have person");
 
-            assert_eq!(&person_v1, &person);
+            // When we query v2 at snapshot 1, we should not get a result because the update happened after the snapshot
+            assert_eq!(
+                get_test_person_at_version(
+                    &mut table,
+                    &add_person.id,
+                    &VersionId(2),
+                    TransactionId::new_first_transaction(),
+                ),
+                None
+            );
         }
 
         #[test]
-        fn add_update_then_get_person_at_version() {
+        pub fn list_right_item_returned_for_snapshot_id() {
             // Given an empty table
             let mut table = PersonTable::new();
 
             // When we add an item
-            let (person, next_transaction_id) = add_test_person_to_empty_database(&mut table);
+            let (expected_added_person, next_transaction_id) =
+                add_test_person_to_empty_database(&mut table);
 
             // And we update the item
-            let (updated_person, next_transaction_id) =
-                update_test_person(&mut table, &person, next_transaction_id);
-
-            // Then we should be able to get the item at version 1
-            let person_v1 = get_test_person_at_version(
+            let (expected_updated_person, _) = update_test_person(
                 &mut table,
-                &person.id,
-                &VersionId(1),
-                next_transaction_id.clone(),
-            )
-            .expect("should have person");
-
-            assert_eq!(&person_v1, &person);
-
-            // Then we should be able to get the item at version 2
-            let person_v2 = get_test_person_at_version(
-                &mut table,
-                &person.id,
-                &VersionId(2),
-                next_transaction_id.clone(),
-            )
-            .expect("should have person");
-
-            assert_eq!(&person_v2, &updated_person);
-        }
-
-        #[test]
-        fn add_update_delete_then_get_person_at_version() {
-            // Given an empty table
-            let mut table = PersonTable::new();
-
-            // When we add an item
-            let (person, next_transaction_id) = add_test_person_to_empty_database(&mut table);
-
-            // And we update the item
-            let (updated_person, next_transaction_id) =
-                update_test_person(&mut table, &person, next_transaction_id);
-
-            // And we delete the item
-            let next_transaction_id =
-                delete_test_person(&mut table, &person.id, next_transaction_id);
-
-            // Then we should be able to get the item at version 1
-            let person_v1 = get_test_person_at_version(
-                &mut table,
-                &person.id,
-                &VersionId(1),
-                next_transaction_id.clone(),
-            )
-            .expect("should have person");
-
-            assert_eq!(&person_v1, &person);
-
-            // Then we should be able to get the item at version 2
-            let person_v2 = get_test_person_at_version(
-                &mut table,
-                &person.id,
-                &VersionId(2),
-                next_transaction_id.clone(),
-            )
-            .expect("should have person");
-
-            assert_eq!(&person_v2, &updated_person);
-
-            // Then we should NOT be able to get the item at version 3
-            let person_v3 = get_test_person_at_version(
-                &mut table,
-                &person.id,
-                &VersionId(3),
+                &expected_added_person,
                 next_transaction_id.clone(),
             );
 
-            assert!(person_v3.is_none());
+            // We should be able to query the person we added
+            let actual_added_person_list =
+                get_test_list_person(&mut table, TransactionId::new_first_transaction());
+
+            assert_eq!(&vec![expected_added_person], &actual_added_person_list);
+
+            // When we query v2 at snapshot 1, we should not get a result because the update happened after the snapshot
+            let actual_added_person_list = get_test_list_person(&mut table, next_transaction_id);
+
+            assert_eq!(&vec![expected_updated_person], &actual_added_person_list);
         }
     }
 
@@ -897,5 +973,68 @@ mod versioning {
                 None
             }
         }
+    }
+
+    #[allow(dead_code)]
+    fn get_test_list_person(
+        table: &mut PersonTable,
+        next_transaction_id: TransactionId,
+    ) -> Vec<Person> {
+        let statement = Statement::List(None);
+        let result = table.apply(statement, next_transaction_id).unwrap();
+
+        match result {
+            StatementResult::List(people) => people,
+            _ => {
+                // Note: Unsure why but cannot panic here, just assert false
+                assert!(false, "should be a list of people");
+                vec![]
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn get_test_person(
+        table: &mut PersonTable,
+        id: &EntityId,
+        next_transaction_id: TransactionId,
+    ) -> Option<Person> {
+        let statement = Statement::Get(id.clone());
+        let result = table.apply(statement, next_transaction_id).unwrap();
+
+        match result {
+            StatementResult::GetSingle(person) => person,
+            _ => {
+                // Note: Unsure why but cannot panic here, just assert false
+                assert!(false, "should be a single person");
+                None
+            }
+        }
+    }
+
+    pub fn list_test(
+        statements: Vec<Statement>,
+        list_statement: Statement,
+        compare_to: Vec<Person>,
+    ) -> () {
+        let table = PersonTable::new();
+        let mut next_transaction_id = TransactionId::new_first_transaction();
+
+        for statement in statements {
+            table.apply(statement, next_transaction_id.clone()).unwrap();
+            next_transaction_id = next_transaction_id.increment();
+        }
+
+        let mut list_results = table
+            .apply(list_statement, next_transaction_id)
+            .unwrap()
+            .list();
+
+        let mut sort_compare_to = compare_to;
+
+        sort_list(&mut list_results);
+        sort_list(&mut sort_compare_to);
+
+        assert_eq!(&list_results, &sort_compare_to);
     }
 }

--- a/database/src/database/table/table.rs
+++ b/database/src/database/table/table.rs
@@ -15,8 +15,7 @@ use crate::{
 use super::{
     query::{filter, query},
     row::{
-        ApplyDeleteResult, ApplyUpdateResult, DropRow, PersonRow, PersonVersion,
-        PersonVersionState, UpdateStatement,
+        ApplyDeleteResult, ApplyUpdateResult, DropRow, PersonRow, PersonVersion, PersonVersionState,
     },
 };
 
@@ -275,7 +274,7 @@ fn sort_list(people: &mut Vec<Person>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database::table::row::UpdatePersonData;
+    use crate::database::table::row::{UpdatePersonData, UpdateStatement};
 
     // TODO:
     //  - There should be a better way of comparing lists of a default sort (sort_list)
@@ -427,7 +426,10 @@ mod tests {
         }
 
         mod update {
-            use crate::database::table::query::{QueryMatch, QueryPersonData};
+            use crate::database::table::{
+                query::{QueryMatch, QueryPersonData},
+                row::UpdateStatement,
+            };
 
             use super::*;
 

--- a/database/src/database/utils/crash.rs
+++ b/database/src/database/utils/crash.rs
@@ -6,14 +6,18 @@ use crate::persistence::storage::StorageError;
 
 #[derive(Error, Debug)]
 pub enum DatabaseCrash {
+    /// We commit to the in memory structure before writing to the WAL, if the WAL write fails
+    /// we have an inconsistent state
     #[error("Inconsistent, uncommitted world state due to storage error: {0}")]
     InconsistentUncommittedInMemoryWorldStateFromWALWrite(StorageError),
 
-    // We snapshot the world state and trim the wal, either could be inconsistent
+    /// World state creation / WAL not currently implemented as an atomic operation
+    /// this error is what happens when there are inconsistencies due to a storage error
     #[error("Inconsistent snapshot disk state due to storage error: {0}")]
     InconsistentStorageFromSnapshot(StorageError),
 
-    /// We reset both the WAL / Snapshots, either could be inconsistent
+    /// Cleaning up table state / the WAL is not currently implemented as an atomic operation
+    /// this error is what happens when there are inconsistencies due to a storage error
     #[error("Inconsistent storage from restarting database: {0}")]
     InconsistentStorageFromReset(StorageError),
 

--- a/database/src/persistence/snapshot.rs
+++ b/database/src/persistence/snapshot.rs
@@ -18,12 +18,11 @@ enum FileType {
     Snapshot,
 }
 
-// TODO: Remove the filetype, should be dependent of the storage layer
 impl FileType {
     fn as_str(&self) -> &'static str {
         match self {
-            FileType::Metadata => "metadata.json",
-            FileType::Snapshot => "snapshot.json",
+            FileType::Metadata => "metadata",
+            FileType::Snapshot => "snapshot",
         }
     }
 }

--- a/database/src/persistence/storage/mod.rs
+++ b/database/src/persistence/storage/mod.rs
@@ -17,9 +17,7 @@ pub mod network;
 pub mod postgres;
 pub mod s3;
 
-// TODO: Consider grouping these errors into submodules, as storage provider it would be significantly clearer which error is
-//  related to which command
-// NOTE: Our use of anyhow is because each storage provider will return a different error type
+// Our use of anyhow is because each storage provider will return a different error type
 //  this means we cannot just standardize on something like say IO Error.
 #[derive(Error, Debug)]
 pub enum StorageError {

--- a/database/src/persistence/transaction.rs
+++ b/database/src/persistence/transaction.rs
@@ -189,6 +189,10 @@ impl TransactionWAL {
         Ok(flushed_size)
     }
 
+    pub fn get_wal_size(&self) -> usize {
+        self.size.load(Ordering::SeqCst)
+    }
+
     pub fn get_increment_current_transaction_id(&self) -> TransactionId {
         self.current_transaction_id.get_timestamp()
     }

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -127,3 +127,18 @@ By using MVCC we do not need to implement the more complicated 2PL (2 Phase Lock
         SearchMethod::RequiresFullScan
     };
 ```
+
+
+Ideas:
+1. Snapshot isolation
+    1. Unsure if we're technically there (are we encoding that value somewhere?)
+        1. Which timestamps are there and what do they mean? tx start, and tx commit? -- look into whitepaper
+    1. Query at any clock time
+1. Review transaction lifecycle (as described in the white paper)
+1. Long lived transactions
+    1. Setting up the Infrastructure w/ GraphQL (transaction identifier, clock time)
+    1. Query at a point in time
+1. Database write lock barrier sync poorman's serializable writes
+1. Indexes
+    1. Uniqueness
+    2. Query performance


### PR DESCRIPTION
Changes:
- Adds the ability to query against a snapshot id
- Fixes issues with GET / GET_VERSION internal APIs which were not correctly querying against the snapshot id
- Adds a `databaseInfo` query
- Moves the transaction id to increment on every command 
- Removes un-needed mutex around request manager in graphql
- Fixes a bug with transaction ID not being applied from the WAL replay

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/44d1dd92-83f5-419c-88d5-828ad1d572d3">

